### PR TITLE
Enable newsletter and contact form functionality

### DIFF
--- a/script.js
+++ b/script.js
@@ -8,11 +8,43 @@ window.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  document.querySelectorAll('form').forEach(form => {
-    form.addEventListener('submit', e => {
+  const showMessage = (form, text) => {
+    const msg = document.createElement('p');
+    msg.className = 'form-message';
+    msg.textContent = text;
+    form.appendChild(msg);
+    setTimeout(() => msg.remove(), 5000);
+  };
+
+  const storeData = (key, data) => {
+    const existing = JSON.parse(localStorage.getItem(key) || '[]');
+    existing.push(data);
+    localStorage.setItem(key, JSON.stringify(existing));
+  };
+
+  const contactForm = document.querySelector('.contact-form form');
+  if (contactForm) {
+    contactForm.addEventListener('submit', e => {
       e.preventDefault();
-      alert('Thank you! We will be in touch soon.');
-      form.reset();
+      storeData('contacts', {
+        name: contactForm.name.value,
+        email: contactForm.email.value,
+        message: contactForm.message.value,
+        ts: Date.now()
+      });
+      contactForm.reset();
+      showMessage(contactForm, 'Message sent! We will be in touch soon.');
     });
-  });
+  }
+
+  const newsletterForm = document.querySelector('#newsletter form');
+  if (newsletterForm) {
+    const emailInput = newsletterForm.querySelector('input[type="email"]');
+    newsletterForm.addEventListener('submit', e => {
+      e.preventDefault();
+      storeData('signups', { email: emailInput.value, ts: Date.now() });
+      newsletterForm.reset();
+      showMessage(newsletterForm, 'Thanks for signing up!');
+    });
+  }
 });

--- a/style.css
+++ b/style.css
@@ -154,6 +154,29 @@ main {
     text-align: center;
 }
 
+.newsletter form {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--spacing-xs);
+    margin-top: var(--spacing-sm);
+}
+
+.newsletter input {
+    padding: var(--spacing-xs);
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    color: var(--color-dark);
+    width: 100%;
+    max-width: 300px;
+}
+
+.form-message {
+    margin-top: var(--spacing-xs);
+    font-weight: 600;
+    color: var(--color-dark);
+}
+
 .site-footer {
     background: var(--color-dark);
     color: var(--color-light);


### PR DESCRIPTION
## Summary
- store contact and newsletter submissions in localStorage
- show in-page confirmation messages on success
- style newsletter form like contact form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ba1a1562c8330ada944d8185c2027