### PR TITLE
Add detailed content to services page

### DIFF
--- a/services.html
+++ b/services.html
@@ -37,19 +37,44 @@
             </div>
         </section>
 
-        <section class="service-list">
+        <section class="services">
             <div class="container">
-                <div class="service-item">
-                    <h2>Consulting</h2>
-                    <p>Get expert advice on modern frameworks and best practices.</p>
-                </div>
-                <div class="service-item">
-                    <h2>Training</h2>
-                    <p>Hands-on sessions for teams and individuals looking to expand their skills.</p>
-                </div>
-                <div class="service-item">
-                    <h2>Project Collaboration</h2>
-                    <p>Partner with us for your next big idea and benefit from our industry experience.</p>
+                <h2>What We Offer</h2>
+                <div class="service-list">
+                    <div class="service-item">
+                        <h3>Consulting That Clarifies, Not Complicates</h3>
+                        <p>Whether you're starting from scratch or refining your tech stack, we offer honest, actionable guidance grounded in both academic research and real-world development.</p>
+                        <ul>
+                            <li>Get clarity on the right tools and modern frameworks</li>
+                            <li>Discover best practices that actually make sense for your context</li>
+                            <li>Build with confidence and intention &mdash; not guesswork</li>
+                            <li>Trusted by educators, founders, and creative professionals who value depth and clarity</li>
+                        </ul>
+                    </div>
+                    <div class="service-item">
+                        <h3>Training That Builds Confidence</h3>
+                        <p>We deliver interactive, hands-on training sessions for individuals, educators, and teams &mdash; helping you move from theory to fluent practice.</p>
+                        <ul>
+                            <li>Learn the why, not just the how</li>
+                            <li>Master modern web technologies, design thinking, and AI tools</li>
+                            <li>Get personalized feedback, code reviews, and post-session follow-ups</li>
+                            <li>Great for schools, internal upskilling, or professional development programs</li>
+                        </ul>
+                    </div>
+                    <div class="service-item">
+                        <h3>Project Collaboration With Purpose</h3>
+                        <p>Have a big idea, but need the right partner to bring it to life? We work closely with you from vision to launch &mdash; combining strategy, creativity, and execution.</p>
+                        <ul>
+                            <li>We listen, prototype, and iterate with you</li>
+                            <li>Clear deliverables, realistic timelines, and respectful workflows</li>
+                            <li>Your goals drive the process &mdash; we bring the experience, structure, and technical strength</li>
+                            <li>Let&rsquo;s co-create something that actually works &mdash; and that you&rsquo;ll be proud of</li>
+                        </ul>
+                    </div>
+                    <div class="service-item">
+                        <h3>Our Approach: Thoughtful, Personal, Reliable</h3>
+                        <p>We don&rsquo;t believe in buzzwords or shortcuts. We believe in good communication, quality work, and shared values. If you&rsquo;re looking for a partner, not just a service, you&rsquo;re in the right place.</p>
+                    </div>
                 </div>
             </div>
         </section>

--- a/style.css
+++ b/style.css
@@ -194,6 +194,13 @@ section {
     text-align: center;
 }
 
+.service-item ul {
+    margin: var(--spacing-sm) 0;
+    list-style: disc;
+    margin-left: 1.2rem;
+    text-align: left;
+}
+
 /* Features grid on the home page */
 .features {
     background: var(--color-light);


### PR DESCRIPTION
## Summary
- expand Services page with descriptive sections for Consulting, Training, Project Collaboration, and approach
- style bullet lists inside service items

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688bcc7424c08330afe0c5cfdd79f22d