### PR TITLE
Fix spacing around testimonial scroll buttons

### DIFF
--- a/style.css
+++ b/style.css
@@ -376,6 +376,8 @@ section {
     gap: var(--spacing-sm);
     scroll-snap-type: x mandatory;
     padding-bottom: var(--spacing-sm);
+    padding-left: var(--spacing-md);
+    padding-right: var(--spacing-md);
     scrollbar-width: none;
 }
 .testimonial-scroller::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- adjust testimonial scroller padding so arrows don't overlap cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688cddf2c68883309065388c1d382a9d