### PR TITLE
Fix testimonial arrow spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -375,7 +375,7 @@ section {
     overflow-x: auto;
     gap: var(--spacing-sm);
     scroll-snap-type: x mandatory;
-    padding-bottom: var(--spacing-sm);
+    padding: 0 3rem var(--spacing-sm);
     scrollbar-width: none;
 }
 .testimonial-scroller::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- add horizontal padding to `.testimonial-scroller` to keep arrows from overlapping cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688cddf2c68883309065388c1d382a9d